### PR TITLE
downgrade to alpha.5

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 fil_actors_runtime = { path = "../runtime", features = ["test_utils", "fil-actor"] }
 primitives = { path = "../primitives" }
 
-fvm_shared = { version = "3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 fil_actors_runtime = { path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "3.0.0-alpha.12", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_shared = { version = "3.0.0-alpha.12", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -30,7 +30,7 @@ rand = "0.7.3"
 
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
-fvm_sdk = { version = "3.0.0-alpha.14", optional = true }
+fvm_sdk = { version = "=3.0.0-alpha.5", optional = true }
 blake2b_simd = "1.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.0"

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -268,7 +268,7 @@ where
     }
 
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {
-        Ok(fvm::actor::next_actor_address())
+        Ok(fvm::actor::new_actor_address())
     }
 
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->
Current `lotus` fvm seems does not work with current main branch `fvm_*` version, too high. Downgrade to make it work.

- Downgrade `fvm_*` to `3.0.0.alpha.5`.
- Force set the versions so far until we have a more stable release in `fvm`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo test
```
