### PR TITLE
support struct signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2021"
 [dependencies]
 fil_actors_runtime = { path = "./runtime", features = ["test_utils", "fil-actor"] }
 primitives = { path = "primitives" }
+interface-trait = { version = "0.1.0", path = "interface-trait" }
+interface-derive = { version = "0.1.0", path = "interface-derive" }
 
 [workspace]
 members = [
     "runtime",
     "primitives",
     "example",
+    "interface-derive",
+    "interface-trait",
 ]

--- a/interface-derive/Cargo.toml
+++ b/interface-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "interface-derive"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0.105", features = ["full", "extra-traits"] }
+
+[lib]
+proc-macro = true

--- a/interface-derive/src/lib.rs
+++ b/interface-derive/src/lib.rs
@@ -21,15 +21,16 @@ fn impl_method_signature(ast: &syn::DeriveInput) -> TokenStream {
         // TODO: we should explore converting `field.ty` to bytes then we can generate
         // TODO: the hash offline. Anyone has any tips?
         match fields {
-            Fields::Named(ref fields) => {
-                fields.named.iter().map(|field| field.ty.clone()).collect::<Vec<_>>()
-            }
+            Fields::Named(ref fields) => fields
+                .named
+                .iter()
+                .map(|field| field.ty.clone())
+                .collect::<Vec<_>>(),
             _ => {
                 panic!("The StructSignature derive macro can only be applied to named fields.");
             }
         }
-    }
-    else {
+    } else {
         panic!("The StructSignature derive macro can only be applied to structs.");
     };
 

--- a/interface-derive/src/lib.rs
+++ b/interface-derive/src/lib.rs
@@ -1,0 +1,50 @@
+use proc_macro::{self, TokenStream};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Fields};
+
+#[proc_macro_derive(StructSignature)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let i: DeriveInput = parse_macro_input!(input);
+    impl_method_signature(&i)
+}
+
+fn impl_method_signature(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    // A failed experiment to access to the fields of MyStruct
+    // The next line doesn't compiles
+    let field_types = if let syn::Data::Struct(data) = &ast.data {
+        let fields = &data.fields;
+
+        // TODO: ideally we should be able to generate the hash in this function,
+        // TODO: but somehow I just cannot get the `field.ty` to String or bytes
+        // TODO: we should explore converting `field.ty` to bytes then we can generate
+        // TODO: the hash offline. Anyone has any tips?
+        match fields {
+            Fields::Named(ref fields) => {
+                fields.named.iter().map(|field| field.ty.clone()).collect::<Vec<_>>()
+            }
+            _ => {
+                panic!("The StructSignature derive macro can only be applied to named fields.");
+            }
+        }
+    }
+    else {
+        panic!("The StructSignature derive macro can only be applied to structs.");
+    };
+
+    let tokens = quote! {
+        impl StructSignature for #name {
+            const SIGNATURE_STR: &'static str = stringify!(#(#field_types),*);
+
+            fn signature() -> String {
+                use interface_trait::blake2::{Blake2b512, Digest};
+                let mut hasher = Blake2b512::new();
+                hasher.update(Self::SIGNATURE_STR);
+                interface_trait::hex::encode(hasher.finalize().to_vec())
+            }
+        }
+    };
+
+    tokens.into()
+}

--- a/interface-trait/Cargo.toml
+++ b/interface-trait/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "interface-trait"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+blake2 = "0.10.5"
+interface-derive = { path = "../interface-derive" }
+hex = "0.4.3"

--- a/interface-trait/src/lib.rs
+++ b/interface-trait/src/lib.rs
@@ -1,10 +1,9 @@
-pub use interface_derive::StructSignature;
 pub use blake2;
 pub use hex;
+pub use interface_derive::StructSignature;
 
 pub trait StructSignature {
     const SIGNATURE_STR: &'static str;
 
     fn signature() -> String;
 }
-

--- a/interface-trait/src/lib.rs
+++ b/interface-trait/src/lib.rs
@@ -1,0 +1,10 @@
+pub use interface_derive::StructSignature;
+pub use blake2;
+pub use hex;
+
+pub trait StructSignature {
+    const SIGNATURE_STR: &'static str;
+
+    fn signature() -> String;
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,17 @@
 pub use fil_actors_runtime as runtime;
 pub use primitives;
+pub use interface_trait::StructSignature;
+
+
+#[test]
+fn demo_struct_signature_derive() {
+    #[derive(StructSignature)]
+    #[allow(dead_code)]
+    struct Foo{
+        pub test: String,
+        pub test2: String,
+        pub test3: Option<String>
+    }
+
+    println!("{:?}", Foo::signature());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,15 @@
 pub use fil_actors_runtime as runtime;
-pub use primitives;
 pub use interface_trait::StructSignature;
-
+pub use primitives;
 
 #[test]
 fn demo_struct_signature_derive() {
     #[derive(StructSignature)]
     #[allow(dead_code)]
-    struct Foo{
+    struct Foo {
         pub test: String,
         pub test2: String,
-        pub test3: Option<String>
+        pub test3: Option<String>,
     }
 
     println!("{:?}", Foo::signature());


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

Implements derive parameter struct method signature hash macro. It will generate a method hash string based on the types of the fields of the struct. Internally it is performing blake2 hashing then hex encoding. As an example, consider this struct:
```rust
struct Foo {
   a: String,
   b: usize,
}
```
It would first concate the types to "String, usize", then blake2 hash the string then hex encode.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

check out `src/lib.rs:7` as an example for demo, it is also part of `cargo test`.

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- https://github.com/consensus-shipyard/ipc-gateway/issues/2
