### PR TITLE
add signable composite type and validate when not type

### DIFF
--- a/runtime/src/builtin/mod.rs
+++ b/runtime/src/builtin/mod.rs
@@ -10,6 +10,8 @@ pub mod network;
 pub mod shared;
 pub mod singletons;
 
+pub const CALLER_TYPES_SIGNABLE: &[Type] = &[Type::Account, Type::Multisig];
+
 /// Identifies the builtin actor types for usage with the
 /// actor::resolve_builtin_actor_type syscall.
 /// Note that there is a mirror of this enum in the FVM SDK src/actors/builtins.rs.

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -30,7 +30,7 @@ where
         Default::default(),
     )
     .map_err(|e| {
-        e.wrap(&format!(
+        e.wrap(format!(
             "failed to send zero balance to address {}",
             address
         ))

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -139,6 +139,29 @@ where
         }
     }
 
+    fn validate_immediate_caller_not_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
+    where
+        I: IntoIterator<Item = &'a Type>,
+    {
+        self.assert_not_validated()?;
+        let caller_cid = {
+            let caller_addr = self.message().caller();
+            self.get_actor_code_cid(&caller_addr)
+                .expect("failed to lookup caller code")
+        };
+
+        match self.resolve_builtin_actor_type(&caller_cid) {
+            Some(typ) if types.into_iter().any(|t| *t == typ) => {
+                Err(actor_error!(forbidden;
+                                 "caller cid type {} is one of the not supported", caller_cid))
+            },
+            _ => {
+                self.caller_validated = true;
+                Ok(())
+            }
+        }
+    }
+
     fn current_balance(&self) -> TokenAmount {
         fvm::sself::current_balance()
     }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -151,10 +151,8 @@ where
         };
 
         match self.resolve_builtin_actor_type(&caller_cid) {
-            Some(typ) if types.into_iter().any(|t| *t == typ) => {
-                Err(actor_error!(forbidden;
-                                 "caller cid type {} is one of the not supported", caller_cid))
-            },
+            Some(typ) if types.into_iter().any(|t| *t == typ) => Err(actor_error!(forbidden;
+                                 "caller cid type {} is one of the not supported", caller_cid)),
             _ => {
                 self.caller_validated = true;
                 Ok(())

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -47,6 +47,9 @@ pub trait Runtime<BS: Blockstore>: Primitives {
     fn validate_immediate_caller_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Type>;
+    fn validate_immediate_caller_not_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
+    where
+        I: IntoIterator<Item = &'a Type>;
 
     /// The balance of the receiver.
     fn current_balance(&self) -> TokenAmount;

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -383,6 +383,14 @@ impl MockRuntime {
     }
 
     #[allow(dead_code)]
+    pub fn expect_validate_caller_not_type(&mut self, types: Vec<Cid>) {
+        // we add type as an expectation to ensure that we did the type check
+        // and then perform the explicit "not_type" check in the validate of
+        // the MockRuntime
+        self.expect_validate_caller_type(types)
+    }
+
+    #[allow(dead_code)]
     pub fn expect_validate_caller_any(&self) {
         self.expectations.borrow_mut().expect_validate_caller_any = true;
     }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Adds a composite type for all signable types so we can perform explicit checks on actors.
- Adds a `validate_immediate_caller` method for the case were we won't to restrict the call for a subset of types.

