### PR TITLE
fix caller not type check

### DIFF
--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -388,7 +388,9 @@ impl MockRuntime {
         // we add type as an expectation to ensure that we did the type check
         // and then perform the explicit "not_type" check in the validate of
         // the MockRuntime
-        self.expectations.borrow_mut().expect_validate_caller_not_type = Some(types);
+        self.expectations
+            .borrow_mut()
+            .expect_validate_caller_not_type = Some(types);
     }
 
     #[allow(dead_code)]
@@ -635,7 +637,9 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
             }
         }
 
-        self.expectations.borrow_mut().expect_validate_caller_not_type = None;
+        self.expectations
+            .borrow_mut()
+            .expect_validate_caller_not_type = None;
         r
     }
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -596,8 +596,6 @@ impl Runtime<MemoryBlockstore> for MockRuntime {
         )
     }
 
-    // TODO: Is this check and `validate_immediate_caller_type` useful at all? It's just doing
-    // TODO: a check passed in the unit test?
     fn validate_immediate_caller_not_type<'a, I>(&mut self, types: I) -> Result<(), ActorError>
     where
         I: IntoIterator<Item = &'a Type>,


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->
As the name suggests, we are checking the caller is not of type for MockRuntime.
