### PR TITLE
Upgrade `fvm` dependencies 

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 fil_actors_runtime = { path = "../runtime", features = ["test_utils", "fil-actor"] }
 primitives = { path = "../primitives" }
 
-fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 num-traits = "0.2.14"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,6 +9,7 @@ fil_actors_runtime = { path = "../runtime", features = ["test_utils", "fil-actor
 primitives = { path = "../primitives" }
 
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
+frc42_dispatch = "3.0.0"
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -2,9 +2,10 @@ mod state;
 
 use crate::state::{State, UserPersistParam};
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
-use fil_actors_runtime::{actor_error, cbor, runtime, ActorDowncast, ActorError, INIT_ACTOR_ADDR};
-use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::RawBytes;
+use fil_actors_runtime::{
+    actor_dispatch, actor_error, restrict_internal_api, runtime, ActorDowncast, ActorError,
+    INIT_ACTOR_ADDR,
+};
 use fvm_shared::error::ExitCode;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 use num_derive::FromPrimitive;
@@ -24,17 +25,12 @@ pub enum Method {
     Persist = 2,
 }
 
-/// Subnet Coordinator Actor
 pub struct Actor;
 
 impl Actor {
     /// Constructor for SCA actor
-    fn constructor<BS, RT>(rt: &mut RT) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
-        rt.validate_immediate_caller_is(std::iter::once(&*INIT_ACTOR_ADDR))?;
+    fn constructor(rt: &mut impl Runtime) -> Result<(), ActorError> {
+        rt.validate_immediate_caller_is(std::iter::once(&INIT_ACTOR_ADDR))?;
         let st = State::new(rt.store()).map_err(|e| {
             e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "Failed to create actor state")
         })?;
@@ -43,11 +39,7 @@ impl Actor {
     }
 
     /// Persists some bytes to storage
-    fn persist<BS, RT>(rt: &mut RT, param: UserPersistParam) -> Result<(), ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    fn persist(rt: &mut impl Runtime, param: UserPersistParam) -> Result<(), ActorError> {
         let caller = rt.message().caller();
 
         rt.validate_immediate_caller_accept_any()?;
@@ -68,74 +60,49 @@ impl Actor {
 }
 
 impl ActorCode for Actor {
-    fn invoke_method<BS, RT>(
-        rt: &mut RT,
-        method: MethodNum,
-        params: &RawBytes,
-    ) -> Result<RawBytes, ActorError>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
-        match FromPrimitive::from_u64(method) {
-            Some(Method::Constructor) => {
-                Self::constructor(rt)?;
-                Ok(RawBytes::default())
-            }
-            Some(Method::Persist) => {
-                Self::persist(rt, cbor::deserialize_params(params)?)?;
-                Ok(RawBytes::serialize(())?)
-            }
-            None => Err(actor_error!(unhandled_message; "Invalid method")),
-        }
+    type Methods = Method;
+    actor_dispatch! {
+        Constructor => constructor,
+        Persist => persist,
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::{Actor, Method, State, UserPersistParam};
-    use fil_actors_runtime::test_utils::MockRuntime;
+    use fil_actors_runtime::test_utils::{MockRuntime, INIT_ACTOR_CODE_ID};
     use fil_actors_runtime::INIT_ACTOR_ADDR;
-    use fvm_ipld_encoding::RawBytes;
+    use fvm_ipld_encoding::ipld_block::IpldBlock;
     use fvm_shared::address::Address;
     use fvm_shared::MethodNum;
 
     #[test]
     fn constructor_works() {
-        let mut rt = MockRuntime::new(Address::new_id(100), *INIT_ACTOR_ADDR);
+        let mut rt = new_runtime();
 
-        rt.expect_validate_caller_addr(vec![*INIT_ACTOR_ADDR]);
+        rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
+        rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
 
-        rt.call::<Actor>(
-            Method::Constructor as MethodNum,
-            &RawBytes::serialize(()).unwrap(),
-        )
-        .unwrap();
+        rt.call::<Actor>(Method::Constructor as MethodNum, None)
+            .unwrap();
 
         rt.verify()
     }
 
     #[test]
     fn persists_works() {
-        let mut rt = MockRuntime::new(Address::new_id(1), *INIT_ACTOR_ADDR);
+        let mut rt = new_runtime();
 
-        rt.expect_validate_caller_addr(vec![*INIT_ACTOR_ADDR]);
+        rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
+        rt.expect_validate_caller_addr(vec![INIT_ACTOR_ADDR]);
 
-        rt.call::<Actor>(
-            Method::Constructor as MethodNum,
-            &RawBytes::serialize(()).unwrap(),
-        )
-        .unwrap();
-
-        // rt.set_caller(Cid::default(), *SYSTEM_ACTOR_ADDR);
-        // let raw = RawBytes::serialize(UserPersistParam { name: String::from("sample") }).unwrap();
-        // let vec_bytes = Vec::from(raw);
-        // println!("{:?}", base64::encode(vec_bytes));
+        rt.call::<Actor>(Method::Constructor as MethodNum, None)
+            .unwrap();
 
         rt.expect_validate_caller_any();
         rt.call::<Actor>(
             Method::Persist as MethodNum,
-            &RawBytes::serialize(UserPersistParam {
+            IpldBlock::serialize_cbor(&UserPersistParam {
                 name: String::from("sample"),
             })
             .unwrap(),
@@ -145,5 +112,13 @@ mod test {
         rt.verify();
         let state: State = rt.get_state();
         assert_eq!(state.call_count, 1);
+    }
+
+    fn new_runtime() -> MockRuntime {
+        MockRuntime {
+            receiver: Address::new_id(1),
+            caller: INIT_ACTOR_ADDR,
+            ..Default::default()
+        }
     }
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -22,7 +22,7 @@ pub fn invoke(param: u32) -> u32 {
 pub enum Method {
     /// Constructor for Storage Power Actor
     Constructor = METHOD_CONSTRUCTOR,
-    Persist = 2,
+    Persist = frc42_dispatch::method_hash!("Persist"),
 }
 
 pub struct Actor;

--- a/example/src/state.rs
+++ b/example/src/state.rs
@@ -1,6 +1,5 @@
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::Cbor;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use primitives::{TCid, THamt};
@@ -25,8 +24,6 @@ pub struct State {
     pub call_count: usize,
     pub typed_hamt: TCid<THamt<Cid, User>>,
 }
-
-impl Cbor for State {}
 
 impl State {
     pub fn new<BS: Blockstore>(store: &BS) -> anyhow::Result<Self> {

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 
 [dependencies]
 fil_actors_runtime = { path = "../runtime", features = ["fil-actor"] }
-fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/primitives/src/taddress.rs
+++ b/primitives/src/taddress.rs
@@ -4,7 +4,6 @@ use std::{convert::TryFrom, fmt::Display, marker::PhantomData, str::FromStr};
 
 use serde::de::Error;
 
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::{Address, Payload};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -112,13 +111,6 @@ where
     }
 }
 
-impl<T> Cbor for TAddress<T>
-where
-    Self: TryFrom<Address>,
-    <Self as TryFrom<Address>>::Error: Display,
-{
-}
-
 /// Apparently CBOR has problems using `Address` as a key in `HashMap`.
 /// This type can be used to wrap an address and turn it into `String`
 /// for the purpose of CBOR serialization.
@@ -152,11 +144,4 @@ where
             .map_err(|e| D::Error::custom(format!("wrong address type: {}", e)))?;
         Ok(Self(addr))
     }
-}
-
-impl<T> Cbor for TAddressKey<T>
-where
-    TAddress<T>: TryFrom<Address>,
-    <TAddress<T> as TryFrom<Address>>::Error: Display,
-{
 }

--- a/primitives/src/taddress.rs
+++ b/primitives/src/taddress.rs
@@ -106,7 +106,7 @@ where
         let raw = Address::deserialize(deserializer)?;
         match Self::try_from(raw) {
             Ok(addr) => Ok(addr),
-            Err(e) => Err(D::Error::custom(format!("wrong address type: {}", e))),
+            Err(e) => Err(D::Error::custom(format!("wrong address type: {e}"))),
         }
     }
 }
@@ -139,9 +139,9 @@ where
     {
         let str = String::deserialize(deserializer)?;
         let raw = Address::from_str(&str)
-            .map_err(|e| D::Error::custom(format!("not an address string: {:?}", e)))?;
+            .map_err(|e| D::Error::custom(format!("not an address string: {e:?}")))?;
         let addr = TAddress::<T>::try_from(raw)
-            .map_err(|e| D::Error::custom(format!("wrong address type: {}", e)))?;
+            .map_err(|e| D::Error::custom(format!("wrong address type: {e}")))?;
         Ok(Self(addr))
     }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/builtin-actors"
 [dependencies]
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_amt = { version = "0.4.2", features = ["go-interop"] }
-fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -30,10 +30,10 @@ rand = "0.7.3"
 
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
-fvm_sdk = { version = "=3.0.0-alpha.5", optional = true }
+fvm_sdk = { version = "=3.0.0-alpha.22", optional = true }
 blake2b_simd = "1.0"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 multihash = { version = "0.16.1", default-features = false }
 serde_repr = "0.1.8"
 regex = "1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,11 +23,10 @@ base64 = "0.13.0"
 log = "0.4.14"
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 thiserror = "1.0.30"
+castaway = "0.2.2"
 # enforce wasm compat
-
 getrandom = { version = "0.2.3", features = ["js"]}
 rand = "0.7.3"
-
 hex = { version = "0.4.3", optional = true }
 anyhow = "1.0.56"
 fvm_sdk = { version = "=3.0.0-alpha.22", optional = true }
@@ -38,6 +37,8 @@ multihash = { version = "0.16.1", default-features = false }
 serde_repr = "0.1.8"
 regex = "1"
 itertools = "0.10"
+paste = "1.0.9"
+
 
 [dependencies.sha2]
 version = "0.10"

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -22,11 +22,19 @@ impl ActorError {
     /// Creates a new ActorError. This method does not check that the code is in the
     /// range of valid actor abort codes.
     pub fn unchecked(code: ExitCode, msg: String) -> Self {
-        Self { exit_code: code, msg, data: None }
+        Self {
+            exit_code: code,
+            msg,
+            data: None,
+        }
     }
 
     pub fn unchecked_with_data(code: ExitCode, msg: String, data: Option<IpldBlock>) -> Self {
-        Self { exit_code: code, msg, data }
+        Self {
+            exit_code: code,
+            msg,
+            data,
+        }
     }
 
     /// Creates a new ActorError. This method checks if the exit code is within the allowed range,
@@ -43,35 +51,75 @@ impl ActorError {
             // Otherwise, pass it through.
             code => code,
         };
-        Self { exit_code, msg, data }
+        Self {
+            exit_code,
+            msg,
+            data,
+        }
     }
 
     pub fn illegal_argument(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
+            msg,
+            data: None,
+        }
     }
     pub fn not_found(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_NOT_FOUND, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_NOT_FOUND,
+            msg,
+            data: None,
+        }
     }
     pub fn forbidden(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_FORBIDDEN, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_FORBIDDEN,
+            msg,
+            data: None,
+        }
     }
     pub fn insufficient_funds(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_INSUFFICIENT_FUNDS, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_INSUFFICIENT_FUNDS,
+            msg,
+            data: None,
+        }
     }
     pub fn illegal_state(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_ILLEGAL_STATE,
+            msg,
+            data: None,
+        }
     }
     pub fn serialization(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_SERIALIZATION, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_SERIALIZATION,
+            msg,
+            data: None,
+        }
     }
     pub fn unhandled_message(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_UNHANDLED_MESSAGE, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_UNHANDLED_MESSAGE,
+            msg,
+            data: None,
+        }
     }
     pub fn unspecified(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_UNSPECIFIED, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_UNSPECIFIED,
+            msg,
+            data: None,
+        }
     }
     pub fn assertion_failed(msg: String) -> Self {
-        Self { exit_code: ExitCode::USR_ASSERTION_FAILED, msg, data: None }
+        Self {
+            exit_code: ExitCode::USR_ASSERTION_FAILED,
+            msg,
+            data: None,
+        }
     }
 
     /// Returns the exit code of the error.
@@ -99,7 +147,11 @@ impl ActorError {
 /// Converts a raw encoding error into an ErrSerialization.
 impl From<fvm_ipld_encoding::Error> for ActorError {
     fn from(e: fvm_ipld_encoding::Error) -> Self {
-        Self { exit_code: ExitCode::USR_SERIALIZATION, msg: e.to_string(), data: None }
+        Self {
+            exit_code: ExitCode::USR_SERIALIZATION,
+            msg: e.to_string(),
+            data: None,
+        }
     }
 }
 
@@ -108,7 +160,11 @@ impl From<fvm_ipld_encoding::Error> for ActorError {
 #[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
-        Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg: e.to_string(), data: None }
+        Self {
+            exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
+            msg: e.to_string(),
+            data: None,
+        }
     }
 }
 
@@ -117,7 +173,11 @@ impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
 #[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::StateReadError> for ActorError {
     fn from(e: fvm_sdk::error::StateReadError) -> Self {
-        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, data: None, msg: e.to_string() }
+        Self {
+            exit_code: ExitCode::USR_ILLEGAL_STATE,
+            data: None,
+            msg: e.to_string(),
+        }
     }
 }
 
@@ -209,7 +269,11 @@ pub trait AsActorError<T>: Sized {
 // Note: E should be std::error::Error, revert to this after anyhow:Error is no longer used.
 impl<T, E: Display> AsActorError<T> for Result<T, E> {
     fn exit_code(self, code: ExitCode) -> Result<T, ActorError> {
-        self.map_err(|err| ActorError { exit_code: code, msg: err.to_string(), data: None })
+        self.map_err(|err| ActorError {
+            exit_code: code,
+            msg: err.to_string(),
+            data: None,
+        })
     }
 
     fn context_code<C>(self, code: ExitCode, context: C) -> Result<T, ActorError>
@@ -218,7 +282,7 @@ impl<T, E: Display> AsActorError<T> for Result<T, E> {
     {
         self.map_err(|err| ActorError {
             exit_code: code,
-            msg: format!("{}: {}", context, err),
+            msg: format!("{context}: {err}"),
             data: None,
         })
     }
@@ -238,14 +302,22 @@ impl<T, E: Display> AsActorError<T> for Result<T, E> {
 
 impl<T> AsActorError<T> for Option<T> {
     fn exit_code(self, code: ExitCode) -> Result<T, ActorError> {
-        self.ok_or_else(|| ActorError { exit_code: code, msg: "None".to_string(), data: None })
+        self.ok_or_else(|| ActorError {
+            exit_code: code,
+            msg: "None".to_string(),
+            data: None,
+        })
     }
 
     fn context_code<C>(self, code: ExitCode, context: C) -> Result<T, ActorError>
     where
         C: Display + 'static,
     {
-        self.ok_or_else(|| ActorError { exit_code: code, msg: context.to_string(), data: None })
+        self.ok_or_else(|| ActorError {
+            exit_code: code,
+            msg: context.to_string(),
+            data: None,
+        })
     }
 
     fn with_context_code<C, F>(self, code: ExitCode, f: F) -> Result<T, ActorError>
@@ -253,7 +325,11 @@ impl<T> AsActorError<T> for Option<T> {
         C: Display + 'static,
         F: FnOnce() -> C,
     {
-        self.ok_or_else(|| ActorError { exit_code: code, msg: f().to_string(), data: None })
+        self.ok_or_else(|| ActorError {
+            exit_code: code,
+            msg: f().to_string(),
+            data: None,
+        })
     }
 }
 
@@ -261,7 +337,10 @@ pub fn deserialize_block<T>(ret: Option<IpldBlock>) -> Result<T, ActorError>
 where
     T: DeserializeOwned,
 {
-    ret.context_code(ExitCode::USR_ASSERTION_FAILED, "return expected".to_string())?
-        .deserialize()
-        .exit_code(ExitCode::USR_SERIALIZATION)
+    ret.context_code(
+        ExitCode::USR_ASSERTION_FAILED,
+        "return expected".to_string(),
+    )?
+    .deserialize()
+    .exit_code(ExitCode::USR_SERIALIZATION)
 }

--- a/runtime/src/actor_error.rs
+++ b/runtime/src/actor_error.rs
@@ -1,3 +1,7 @@
+use fvm_ipld_encoding::de::DeserializeOwned;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use std::fmt::Display;
+
 use fvm_shared::error::ExitCode;
 use thiserror::Error;
 
@@ -6,8 +10,10 @@ use thiserror::Error;
 #[error("ActorError(exit_code: {exit_code:?}, msg: {msg})")]
 pub struct ActorError {
     /// The exit code for this invocation.
-    /// Codes less than `FIRST_ACTOR_EXIT_CODE` are prohibited and will be overwritten by the VM.
+    /// Codes less than `FIRST_USER_EXIT_CODE` are prohibited and will be overwritten by the VM.
     exit_code: ExitCode,
+    /// Optional exit data
+    data: Option<IpldBlock>,
     /// Message for debugging purposes,
     msg: String,
 }
@@ -16,65 +22,56 @@ impl ActorError {
     /// Creates a new ActorError. This method does not check that the code is in the
     /// range of valid actor abort codes.
     pub fn unchecked(code: ExitCode, msg: String) -> Self {
-        Self {
-            exit_code: code,
-            msg,
-        }
+        Self { exit_code: code, msg, data: None }
+    }
+
+    pub fn unchecked_with_data(code: ExitCode, msg: String, data: Option<IpldBlock>) -> Self {
+        Self { exit_code: code, msg, data }
+    }
+
+    /// Creates a new ActorError. This method checks if the exit code is within the allowed range,
+    /// and automatically converts it into a user code.
+    pub fn checked(code: ExitCode, msg: String, data: Option<IpldBlock>) -> Self {
+        let exit_code = match code {
+            // This means the called actor did something wrong. We can't "make up" a
+            // reasonable exit code.
+            ExitCode::SYS_MISSING_RETURN
+            | ExitCode::SYS_ILLEGAL_INSTRUCTION
+            | ExitCode::SYS_ILLEGAL_EXIT_CODE => ExitCode::USR_UNSPECIFIED,
+            // We don't expect any other system errors.
+            code if code.is_system_error() => ExitCode::USR_ASSERTION_FAILED,
+            // Otherwise, pass it through.
+            code => code,
+        };
+        Self { exit_code, msg, data }
     }
 
     pub fn illegal_argument(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg, data: None }
     }
     pub fn not_found(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_NOT_FOUND,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_NOT_FOUND, msg, data: None }
     }
     pub fn forbidden(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_FORBIDDEN,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_FORBIDDEN, msg, data: None }
     }
     pub fn insufficient_funds(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_INSUFFICIENT_FUNDS,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_INSUFFICIENT_FUNDS, msg, data: None }
     }
     pub fn illegal_state(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_ILLEGAL_STATE,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, msg, data: None }
     }
     pub fn serialization(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_SERIALIZATION,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_SERIALIZATION, msg, data: None }
     }
     pub fn unhandled_message(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_UNHANDLED_MESSAGE,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_UNHANDLED_MESSAGE, msg, data: None }
     }
     pub fn unspecified(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_UNSPECIFIED,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_UNSPECIFIED, msg, data: None }
     }
     pub fn assertion_failed(msg: String) -> Self {
-        Self {
-            exit_code: ExitCode::USR_ASSERTION_FAILED,
-            msg,
-        }
+        Self { exit_code: ExitCode::USR_ASSERTION_FAILED, msg, data: None }
     }
 
     /// Returns the exit code of the error.
@@ -87,6 +84,11 @@ impl ActorError {
         &self.msg
     }
 
+    /// Extracts the optional associated data without copying.
+    pub fn take_data(&mut self) -> Option<IpldBlock> {
+        std::mem::take(&mut self.data)
+    }
+
     /// Prefix error message with a string message.
     pub fn wrap(mut self, msg: impl AsRef<str>) -> Self {
         self.msg = format!("{}: {}", msg.as_ref(), self.msg);
@@ -97,10 +99,7 @@ impl ActorError {
 /// Converts a raw encoding error into an ErrSerialization.
 impl From<fvm_ipld_encoding::Error> for ActorError {
     fn from(e: fvm_ipld_encoding::Error) -> Self {
-        Self {
-            exit_code: ExitCode::USR_SERIALIZATION,
-            msg: e.to_string(),
-        }
+        Self { exit_code: ExitCode::USR_SERIALIZATION, msg: e.to_string(), data: None }
     }
 }
 
@@ -109,20 +108,30 @@ impl From<fvm_ipld_encoding::Error> for ActorError {
 #[cfg(feature = "fil-actor")]
 impl From<fvm_sdk::error::ActorDeleteError> for ActorError {
     fn from(e: fvm_sdk::error::ActorDeleteError) -> Self {
-        Self {
-            exit_code: ExitCode::USR_ILLEGAL_ARGUMENT,
-            msg: e.to_string(),
-        }
+        Self { exit_code: ExitCode::USR_ILLEGAL_ARGUMENT, msg: e.to_string(), data: None }
     }
 }
 
-/// Converts a no-state error into an an actor error with the appropriate exit code (illegal actor).
+/// Converts a state-read error into an an actor error with the appropriate exit code (illegal actor).
 /// This facilitates propagation.
 #[cfg(feature = "fil-actor")]
-impl From<fvm_sdk::error::NoStateError> for ActorError {
-    fn from(e: fvm_sdk::error::NoStateError) -> Self {
+impl From<fvm_sdk::error::StateReadError> for ActorError {
+    fn from(e: fvm_sdk::error::StateReadError) -> Self {
+        Self { exit_code: ExitCode::USR_ILLEGAL_STATE, data: None, msg: e.to_string() }
+    }
+}
+
+/// Converts a state update error into an an actor error with the appropriate exit code.
+/// This facilitates propagation.
+#[cfg(feature = "fil-actor")]
+impl From<fvm_sdk::error::StateUpdateError> for ActorError {
+    fn from(e: fvm_sdk::error::StateUpdateError) -> Self {
         Self {
-            exit_code: ExitCode::USR_ILLEGAL_STATE,
+            exit_code: match e {
+                fvm_sdk::error::StateUpdateError::ActorDeleted => ExitCode::USR_ILLEGAL_STATE,
+                fvm_sdk::error::StateUpdateError::ReadOnly => ExitCode::USR_READ_ONLY,
+            },
+            data: None,
             msg: e.to_string(),
         }
     }
@@ -146,4 +155,113 @@ macro_rules! actor_error {
     ( $code:ident, $msg:literal $(, $ex:expr)+ ) => {
         $crate::actor_error!($code; $msg $(, $ex)*)
     };
+}
+
+// Adds context to an actor error's descriptive message.
+pub trait ActorContext<T> {
+    fn context<C>(self, context: C) -> Result<T, ActorError>
+    where
+        C: Display + 'static;
+
+    fn with_context<C, F>(self, f: F) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+        F: FnOnce() -> C;
+}
+
+impl<T> ActorContext<T> for Result<T, ActorError> {
+    fn context<C>(self, context: C) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+    {
+        self.map_err(|mut err| {
+            err.msg = format!("{}: {}", context, err.msg);
+            err
+        })
+    }
+
+    fn with_context<C, F>(self, f: F) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+        F: FnOnce() -> C,
+    {
+        self.map_err(|mut err| {
+            err.msg = format!("{}: {}", f(), err.msg);
+            err
+        })
+    }
+}
+
+// Adapts a target into an actor error.
+pub trait AsActorError<T>: Sized {
+    fn exit_code(self, code: ExitCode) -> Result<T, ActorError>;
+
+    fn context_code<C>(self, code: ExitCode, context: C) -> Result<T, ActorError>
+    where
+        C: Display + 'static;
+
+    fn with_context_code<C, F>(self, code: ExitCode, f: F) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+        F: FnOnce() -> C;
+}
+
+// Note: E should be std::error::Error, revert to this after anyhow:Error is no longer used.
+impl<T, E: Display> AsActorError<T> for Result<T, E> {
+    fn exit_code(self, code: ExitCode) -> Result<T, ActorError> {
+        self.map_err(|err| ActorError { exit_code: code, msg: err.to_string(), data: None })
+    }
+
+    fn context_code<C>(self, code: ExitCode, context: C) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+    {
+        self.map_err(|err| ActorError {
+            exit_code: code,
+            msg: format!("{}: {}", context, err),
+            data: None,
+        })
+    }
+
+    fn with_context_code<C, F>(self, code: ExitCode, f: F) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+        F: FnOnce() -> C,
+    {
+        self.map_err(|err| ActorError {
+            exit_code: code,
+            msg: format!("{}: {}", f(), err),
+            data: None,
+        })
+    }
+}
+
+impl<T> AsActorError<T> for Option<T> {
+    fn exit_code(self, code: ExitCode) -> Result<T, ActorError> {
+        self.ok_or_else(|| ActorError { exit_code: code, msg: "None".to_string(), data: None })
+    }
+
+    fn context_code<C>(self, code: ExitCode, context: C) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+    {
+        self.ok_or_else(|| ActorError { exit_code: code, msg: context.to_string(), data: None })
+    }
+
+    fn with_context_code<C, F>(self, code: ExitCode, f: F) -> Result<T, ActorError>
+    where
+        C: Display + 'static,
+        F: FnOnce() -> C,
+    {
+        self.ok_or_else(|| ActorError { exit_code: code, msg: f().to_string(), data: None })
+    }
+}
+
+pub fn deserialize_block<T>(ret: Option<IpldBlock>) -> Result<T, ActorError>
+where
+    T: DeserializeOwned,
+{
+    ret.context_code(ExitCode::USR_ASSERTION_FAILED, "return expected".to_string())?
+        .deserialize()
+        .exit_code(ExitCode::USR_SERIALIZATION)
 }

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -1,22 +1,18 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::address::Address;
-use fvm_shared::METHOD_SEND;
+use fvm_shared::{MethodNum, METHOD_SEND};
 
 use crate::runtime::Runtime;
+use crate::{actor_error, ActorError};
 
 pub const HAMT_BIT_WIDTH: u32 = 5;
 
 /// ResolveToIDAddr resolves the given address to it's ID address form.
 /// If an ID address for the given address dosen't exist yet, it tries to create one by sending
 /// a zero balance to the given address.
-pub fn resolve_to_id_addr<BS, RT>(rt: &mut RT, address: &Address) -> anyhow::Result<Address>
-where
-    BS: Blockstore,
-    RT: Runtime<BS>,
-{
+pub fn resolve_to_id_addr(rt: &mut impl Runtime, address: &Address) -> anyhow::Result<Address> {
     // if we are able to resolve it to an ID address, return the resolved address
     if let Some(addr) = rt.resolve_address(address) {
         return Ok(addr);
@@ -37,4 +33,38 @@ where
             address,
         )
     })
+}
+
+// The lowest FRC-42 method number.
+pub const FIRST_EXPORTED_METHOD_NUMBER: MethodNum = 1 << 24;
+
+// Checks whether the caller is allowed to invoke some method number.
+// All method numbers below the FRC-42 range are restricted to built-in actors
+// (including the account and multisig actors).
+// Methods may subsequently enforce tighter restrictions.
+pub fn restrict_internal_api<RT>(rt: &mut RT, method: MethodNum) -> Result<(), ActorError>
+where
+    RT: Runtime,
+{
+    if method >= FIRST_EXPORTED_METHOD_NUMBER {
+        return Ok(());
+    }
+    let caller = rt.message().caller();
+    let code_cid = rt.get_actor_code_cid(&caller.id().unwrap());
+    match code_cid {
+        None => {
+            return Err(
+                actor_error!(forbidden; "no code for caller {} of method {}", caller, method),
+            )
+        }
+        Some(code_cid) => {
+            let builtin_type = rt.resolve_builtin_actor_type(&code_cid);
+            if builtin_type.is_none() {
+                return Err(
+                    actor_error!(forbidden; "caller {} of method {} must be built-in", caller, method),
+                );
+            }
+        }
+    }
+    Ok(())
 }

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -23,18 +23,13 @@ where
     }
 
     // send 0 balance to the account so an ID address for it is created and then try to resolve
-    rt.send(
-        *address,
-        METHOD_SEND,
-        Default::default(),
-        Default::default(),
-    )
-    .map_err(|e| {
-        e.wrap(format!(
-            "failed to send zero balance to address {}",
-            address
-        ))
-    })?;
+    rt.send(address, METHOD_SEND, Default::default(), Default::default())
+        .map_err(|e| {
+            e.wrap(format!(
+                "failed to send zero balance to address {}",
+                address
+            ))
+        })?;
 
     rt.resolve_address(address).ok_or_else(|| {
         anyhow::anyhow!(

--- a/runtime/src/builtin/shared.rs
+++ b/runtime/src/builtin/shared.rs
@@ -20,12 +20,7 @@ pub fn resolve_to_id_addr(rt: &mut impl Runtime, address: &Address) -> anyhow::R
 
     // send 0 balance to the account so an ID address for it is created and then try to resolve
     rt.send(address, METHOD_SEND, Default::default(), Default::default())
-        .map_err(|e| {
-            e.wrap(format!(
-                "failed to send zero balance to address {}",
-                address
-            ))
-        })?;
+        .map_err(|e| e.wrap(format!("failed to send zero balance to address {address}",)))?;
 
     rt.resolve_address(address).ok_or_else(|| {
         anyhow::anyhow!(

--- a/runtime/src/builtin/singletons.rs
+++ b/runtime/src/builtin/singletons.rs
@@ -1,22 +1,31 @@
-// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
 
-lazy_static! {
-    pub static ref SYSTEM_ACTOR_ADDR: Address         = Address::new_id(0);
-    pub static ref INIT_ACTOR_ADDR: Address           = Address::new_id(1);
-    pub static ref REWARD_ACTOR_ADDR: Address         = Address::new_id(2);
-    pub static ref CRON_ACTOR_ADDR: Address           = Address::new_id(3);
-    pub static ref STORAGE_POWER_ACTOR_ADDR: Address  = Address::new_id(4);
-    pub static ref STORAGE_MARKET_ACTOR_ADDR: Address = Address::new_id(5);
-    pub static ref VERIFIED_REGISTRY_ACTOR_ADDR: Address = Address::new_id(6);
+use paste::paste;
 
-    pub static ref CHAOS_ACTOR_ADDR: Address    = Address::new_id(98);
+macro_rules! define_singletons {
+    ($($name:ident = $id:literal,)*) => {
+        $(
+            paste! {
+                pub const [<$name _ID>]: ActorID = $id;
+                pub const [<$name _ADDR>]: Address = Address::new_id([<$name _ID>]);
+            }
+        )*
+    }
+}
 
-    /// Distinguished AccountActor that is the destination of all burnt funds.
-    pub static ref BURNT_FUNDS_ACTOR_ADDR: Address = Address::new_id(99);
+define_singletons! {
+    SYSTEM_ACTOR = 0,
+    INIT_ACTOR = 1,
+    REWARD_ACTOR = 2,
+    CRON_ACTOR = 3,
+    STORAGE_POWER_ACTOR = 4,
+    STORAGE_MARKET_ACTOR = 5,
+    VERIFIED_REGISTRY_ACTOR = 6,
+    DATACAP_TOKEN_ACTOR = 7,
+    BURNT_FUNDS_ACTOR = 99,
 }
 
 /// Defines first available ID address after builtin actors

--- a/runtime/src/dispatch.rs
+++ b/runtime/src/dispatch.rs
@@ -1,0 +1,180 @@
+use castaway::cast;
+use std::marker::PhantomData;
+
+use fvm_ipld_encoding::ipld_block::IpldBlock;
+use serde::{Deserialize, Serialize};
+
+use crate::ActorError;
+
+/// Implement actor method dispatch:
+///
+/// ```ignore
+/// type Actor;
+/// #[derive(FromPrimitive)]
+/// #[repr(u64)]
+/// enum Method {
+///     Constructor = 1,
+/// }
+/// impl ActorCode for Actor {
+///     type Methods = Method;
+///     actor_dispatch! {
+///         Constructor => constructor,
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! actor_dispatch {
+    ($($method:ident => $func:ident,)*) => {
+        fn invoke_method<RT>(
+            rt: &mut RT,
+            method: MethodNum,
+            args: Option<fvm_ipld_encoding::ipld_block::IpldBlock>,
+        ) -> Result<Option<fvm_ipld_encoding::ipld_block::IpldBlock>, ActorError>
+        where
+            RT: Runtime,
+            RT::Blockstore: Clone,
+        {
+            restrict_internal_api(rt, method)?;
+            match FromPrimitive::from_u64(method) {
+                $(Some(Self::Methods::$method) => $crate::dispatch(rt, Self::$func, &args),)*
+                None => Err(actor_error!(unhandled_message; "invalid method: {}", method)),
+            }
+        }
+    };
+}
+
+pub trait Dispatch<'de, RT> {
+    fn call(
+        self,
+        rt: &mut RT,
+        args: &'de Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError>;
+}
+
+pub struct Dispatcher<F, A> {
+    func: F,
+    _marker: PhantomData<fn(A)>,
+}
+
+impl<F, A> Dispatcher<F, A> {
+    const fn new(f: F) -> Self {
+        Dispatcher {
+            func: f,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Dispatch an actor method, deserializing the input and re-serializing the output.
+///
+/// This method automatically handles:
+///
+/// - Dispatching None/Some based on the number of parameters (0/1).
+/// - Returning None if the return type is `Result<(), ActorError>`.
+pub fn dispatch<'de, F, A, RT>(
+    rt: &mut RT,
+    func: F,
+    arg: &'de Option<IpldBlock>,
+) -> Result<Option<IpldBlock>, ActorError>
+where
+    Dispatcher<F, A>: Dispatch<'de, RT>,
+{
+    Dispatcher::new(func).call(rt, arg)
+}
+
+/// Convert the passed value into an IPLD Block, or None if it's `()`.
+fn maybe_into_block<T: Serialize>(v: T) -> Result<Option<IpldBlock>, ActorError> {
+    if cast!(&v, &()).is_ok() {
+        Ok(None)
+    } else {
+        Ok(IpldBlock::serialize_cbor(&v)?)
+    }
+}
+
+impl<'de, F, R, RT> Dispatch<'de, RT> for Dispatcher<F, ()>
+where
+    F: FnOnce(&mut RT) -> Result<R, ActorError>,
+    R: Serialize,
+{
+    fn call(
+        self,
+        rt: &mut RT,
+        args: &'de Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError> {
+        match args {
+            None => maybe_into_block((self.func)(rt)?),
+            Some(_) => Err(ActorError::illegal_argument(
+                "method expects no arguments".into(),
+            )),
+        }
+    }
+}
+
+impl<'de, F, A, R, RT> Dispatch<'de, RT> for Dispatcher<F, (A,)>
+where
+    F: FnOnce(&mut RT, A) -> Result<R, ActorError>,
+    A: Deserialize<'de>,
+    R: Serialize,
+{
+    fn call(
+        self,
+        rt: &mut RT,
+        args: &'de Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError> {
+        match args {
+            None => Err(ActorError::illegal_argument(
+                "method expects arguments".into(),
+            )),
+            Some(arg) => maybe_into_block((self.func)(rt, arg.deserialize()?)?),
+        }
+    }
+}
+
+#[test]
+fn test_dispatch() {
+    use crate::ActorError;
+    use fvm_ipld_encoding::ipld_block::IpldBlock;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct SomeArgs {
+        foo: String,
+    }
+
+    trait Runtime {}
+    struct MockRuntime;
+    impl Runtime for MockRuntime {}
+
+    fn with_arg(_: &mut impl Runtime, foo: SomeArgs) -> Result<(), ActorError> {
+        assert_eq!(foo.foo, "foo");
+        Ok(())
+    }
+
+    fn with_arg_ret(_: &mut impl Runtime, foo: SomeArgs) -> Result<SomeArgs, ActorError> {
+        Ok(foo)
+    }
+
+    fn without_arg(_: &mut impl Runtime) -> Result<(), ActorError> {
+        Ok(())
+    }
+
+    let mut rt = MockRuntime;
+    let arg = IpldBlock::serialize_cbor(&SomeArgs { foo: "foo".into() })
+        .expect("failed to serialize arguments");
+
+    // Correct dispatch
+    assert!(dispatch(&mut rt, with_arg, &arg)
+        .expect("failed to dispatch")
+        .is_none());
+    assert!(dispatch(&mut rt, without_arg, &None)
+        .expect("failed to dispatch")
+        .is_none());
+    assert_eq!(
+        dispatch(&mut rt, with_arg_ret, &arg).expect("failed to dispatch"),
+        arg
+    );
+
+    // Incorrect dispatch
+    let _ = dispatch(&mut rt, with_arg, &None).expect_err("should have required an argument");
+    let _ = dispatch(&mut rt, without_arg, &arg).expect_err("should have required an argument");
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,9 @@ pub mod builtin;
 pub mod runtime;
 pub mod util;
 
+mod dispatch;
+pub use dispatch::dispatch;
+
 #[cfg(feature = "test_utils")]
 pub mod test_utils;
 

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -2,24 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::RawBytes;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::MethodNum;
 
 use crate::{ActorError, Runtime};
 
 /// Interface for invoking methods on an Actor
 pub trait ActorCode {
+    type Methods;
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
-    fn invoke_method<BS, RT>(
+    fn invoke_method<RT, BS>(
         rt: &mut RT,
         method: MethodNum,
-        params: &RawBytes,
-    ) -> Result<RawBytes, ActorError>
+        params: Option<IpldBlock>,
+    ) -> Result<Option<IpldBlock>, ActorError>
     where
         // TODO: remove the clone requirement on the blockstore when we fix "replica update" to not
         // hold onto state between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        BS: Blockstore + Clone,
-        RT: Runtime<BS>;
+        RT: Runtime<BS>,
+        BS: Blockstore + Clone;
 }

--- a/runtime/src/runtime/actor_code.rs
+++ b/runtime/src/runtime/actor_code.rs
@@ -12,7 +12,7 @@ pub trait ActorCode {
     type Methods;
     /// Invokes method with runtime on the actor's code. Method number will match one
     /// defined by the Actor, and parameters will be serialized and used in execution
-    fn invoke_method<RT, BS>(
+    fn invoke_method<RT>(
         rt: &mut RT,
         method: MethodNum,
         params: Option<IpldBlock>,
@@ -21,6 +21,6 @@ pub trait ActorCode {
         // TODO: remove the clone requirement on the blockstore when we fix "replica update" to not
         // hold onto state between transactions.
         // https://github.com/filecoin-project/builtin-actors/issues/133
-        RT: Runtime<BS>,
-        BS: Blockstore + Clone;
+        RT: Runtime,
+        RT::Blockstore: Blockstore + Clone;
 }

--- a/runtime/src/runtime/empty.rs
+++ b/runtime/src/runtime/empty.rs
@@ -1,0 +1,40 @@
+use std::mem;
+
+use cid::multihash::Multihash;
+use cid::Cid;
+use fvm_ipld_encoding::DAG_CBOR;
+use fvm_shared::crypto::hash::SupportedHashes;
+
+const fn const_unwrap<T: Copy, E>(r: Result<T, E>) -> T {
+    let v = match r {
+        Ok(r) => r,
+        Err(_) => panic!(),
+    };
+    mem::forget(r);
+    v
+}
+
+// 45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
+const EMPTY_ARR_HASH_DIGEST: &[u8] = &[
+    0x45, 0xb0, 0xcf, 0xc2, 0x20, 0xce, 0xec, 0x5b, 0x7c, 0x1c, 0x62, 0xc4, 0xd4, 0x19, 0x3d, 0x38,
+    0xe4, 0xeb, 0xa4, 0x8e, 0x88, 0x15, 0x72, 0x9c, 0xe7, 0x5f, 0x9c, 0x0a, 0xb0, 0xe4, 0xc1, 0xc0,
+];
+
+// bafy2bzacebc3bt6cedhoyw34drrmjvazhu4oj25er2ebk4u445pzycvq4ta4a
+pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
+    DAG_CBOR,
+    const_unwrap(Multihash::wrap(
+        SupportedHashes::Blake2b256 as u64,
+        EMPTY_ARR_HASH_DIGEST,
+    )),
+);
+
+#[test]
+fn test_empty_arr_cid() {
+    use cid::multihash::{Code, MultihashDigest};
+    use fvm_ipld_encoding::to_vec;
+
+    let empty = to_vec::<[(); 0]>(&[]).unwrap();
+    let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));
+    assert_eq!(EMPTY_ARR_CID, expected);
+}

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -3,7 +3,7 @@ use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{to_vec, CborStore, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{to_vec, CborStore, DAG_CBOR};
 use fvm_sdk as fvm;
 use fvm_sdk::NO_DATA_BLOCK_ID;
 use fvm_shared::address::Address;
@@ -18,10 +18,9 @@ use num_traits::Zero;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::cbor::deserialize;
 use crate::runtime::actor_blockstore::ActorBlockstore;
 use crate::runtime::{ActorCode, MessageInfo, Primitives};
-use crate::{actor_error, ActorError, Runtime, Type};
+use crate::{actor_error, deserialize_block, ActorError, Runtime, Type};
 
 pub const PUBKEY_ADDRESS_METHOD: u64 = 2;
 
@@ -440,5 +439,5 @@ where
     };
     let ret = rt.send(&resolved, PUBKEY_ADDRESS_METHOD, None, TokenAmount::zero())?;
 
-    deserialize::<Address>(&ret, "address response")
+    deserialize_block(ret)
 }

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -364,7 +364,7 @@ pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
     std::panic::set_hook(Box::new(|info| {
         fvm::vm::abort(
             ExitCode::USR_ASSERTION_FAILED.value(),
-            Some(&format!("{}", info)),
+            Some(&format!("{info}")),
         )
     }));
 

--- a/runtime/src/runtime/fvm.rs
+++ b/runtime/src/runtime/fvm.rs
@@ -2,10 +2,11 @@ use anyhow::Error;
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{to_vec, Cbor, CborStore, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{to_vec, CborStore, RawBytes, DAG_CBOR};
 use fvm_sdk as fvm;
 use fvm_sdk::NO_DATA_BLOCK_ID;
 use fvm_shared::address::Address;
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
@@ -13,8 +14,9 @@ use fvm_shared::error::{ErrorNumber, ExitCode};
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{ActorID, MethodNum};
 use num_traits::Zero;
-#[cfg(feature = "fake-proofs")]
-use sha2::{Digest, Sha256};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 
 use crate::cbor::deserialize;
 use crate::runtime::actor_blockstore::ActorBlockstore;
@@ -172,7 +174,7 @@ where
         fvm::actor::get_actor_code_cid(addr)
     }
 
-    fn create<C: Cbor>(&mut self, obj: &C) -> Result<(), ActorError> {
+    fn create<T: Serialize>(&mut self, obj: &T) -> Result<(), ActorError> {
         let root = fvm::sself::root()?;
         if root != *EMPTY_ARR_CID {
             return Err(
@@ -185,7 +187,7 @@ where
         Ok(())
     }
 
-    fn state<C: Cbor>(&self) -> Result<C, ActorError> {
+    fn state<T: DeserializeOwned>(&self) -> Result<T, ActorError> {
         let root = fvm::sself::root()?;
         Ok(ActorBlockstore
             .get_cbor(&root)
@@ -193,10 +195,10 @@ where
             .expect("State does not exist for actor state root"))
     }
 
-    fn transaction<C, RT, F>(&mut self, f: F) -> Result<RT, ActorError>
+    fn transaction<S, RT, F>(&mut self, f: F) -> Result<RT, ActorError>
     where
-        C: Cbor,
-        F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>,
+        S: Serialize + DeserializeOwned,
+        F: FnOnce(&mut S, &mut Self) -> Result<RT, ActorError>,
     {
         let state_cid = fvm::sself::root()
             .map_err(|_| actor_error!(illegal_argument; "failed to get actor root state CID"))?;
@@ -204,7 +206,7 @@ where
         log::debug!("getting cid: {}", state_cid);
 
         let mut state = ActorBlockstore
-            .get_cbor::<C>(&state_cid)
+            .get_cbor::<S>(&state_cid)
             .map_err(|_| actor_error!(illegal_argument; "failed to get actor state"))?
             .expect("State does not exist for actor state root");
 
@@ -225,39 +227,26 @@ where
 
     fn send(
         &self,
-        to: Address,
+        to: &Address,
         method: MethodNum,
-        params: RawBytes,
+        params: Option<IpldBlock>,
         value: TokenAmount,
-    ) -> Result<RawBytes, ActorError> {
+    ) -> Result<Option<IpldBlock>, ActorError> {
         if self.in_transaction {
             return Err(actor_error!(assertion_failed; "send is not allowed during transaction"));
         }
-        match fvm::send::send(&to, method, params, value) {
+        match fvm::send::send(to, method, params, value, None, SendFlags::empty()) {
             Ok(ret) => {
                 if ret.exit_code.is_success() {
                     Ok(ret.return_data)
                 } else {
-                    // The returned code can't be simply propagated as it may be a system exit code.
-                    // TODO: improve propagation once we return a RuntimeError.
-                    // Ref https://github.com/filecoin-project/builtin-actors/issues/144
-                    let exit_code = match ret.exit_code {
-                        // This means the called actor did something wrong. We can't "make up" a
-                        // reasonable exit code.
-                        ExitCode::SYS_MISSING_RETURN
-                        | ExitCode::SYS_ILLEGAL_INSTRUCTION
-                        | ExitCode::SYS_ILLEGAL_EXIT_CODE => ExitCode::USR_UNSPECIFIED,
-                        // We don't expect any other system errors.
-                        code if code.is_system_error() => ExitCode::USR_ASSERTION_FAILED,
-                        // Otherwise, pass it through.
-                        code => code,
-                    };
-                    Err(ActorError::unchecked(
-                        exit_code,
+                    Err(ActorError::checked(
+                        ret.exit_code,
                         format!(
                             "send to {} method {} aborted with code {}",
                             to, method, ret.exit_code
                         ),
+                        ret.return_data,
                     ))
                 }
             }
@@ -288,9 +277,11 @@ where
         }
     }
 
+
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {
-        Ok(fvm::actor::new_actor_address())
+        Ok(fvm::actor::next_actor_address())
     }
+
 
     fn create_actor(&mut self, code_id: Cid, actor_id: ActorID) -> Result<(), ActorError> {
         if self.in_transaction {
@@ -369,44 +360,65 @@ where
 /// 5a. In case of error, aborts the execution with the emitted exit code, or
 /// 5b. In case of success, stores the return data as a block and returns the latter.
 pub fn trampoline<C: ActorCode>(params: u32) -> u32 {
-    fvm::debug::init_logging();
+    init_logging();
 
     std::panic::set_hook(Box::new(|info| {
-        fvm::vm::abort(
-            ExitCode::USR_ASSERTION_FAILED.value(),
-            Some(&format!("{}", info)),
-        )
+        fvm::vm::abort(ExitCode::USR_ASSERTION_FAILED.value(), Some(&format!("{}", info)))
     }));
 
     let method = fvm::message::method_number();
-    log::debug!("fetching parameters block: {}", params);
-    let params = fvm::message::params_raw(params)
-        .expect("params block invalid")
-        .1;
-    let params = RawBytes::new(params);
-    log::debug!("input params: {:x?}", params.bytes());
+    let params = fvm::message::params_raw(params).expect("params block invalid");
 
     // Construct a new runtime.
     let mut rt = FvmRuntime::default();
     // Invoke the method, aborting if the actor returns an errored exit code.
-    let ret = C::invoke_method(&mut rt, method, &params)
+    let ret = C::invoke_method(&mut rt, method, params)
         .unwrap_or_else(|err| fvm::vm::abort(err.exit_code().value(), Some(err.msg())));
 
     // Abort with "assertion failed" if the actor failed to validate the caller somewhere.
     // We do this after handling the error, because the actor may have encountered an error before
     // it even could validate the caller.
     if !rt.caller_validated {
-        fvm::vm::abort(
-            ExitCode::USR_ASSERTION_FAILED.value(),
-            Some("failed to validate caller"),
-        )
+        fvm::vm::abort(ExitCode::USR_ASSERTION_FAILED.value(), Some("failed to validate caller"))
     }
 
     // Then handle the return value.
-    if ret.is_empty() {
-        NO_DATA_BLOCK_ID
-    } else {
-        fvm::ipld::put_block(DAG_CBOR, ret.bytes()).expect("failed to write result")
+    match ret {
+        None => NO_DATA_BLOCK_ID,
+        Some(ret_block) => fvm::ipld::put_block(ret_block.codec, ret_block.data.as_slice())
+            .expect("failed to write result"),
+    }
+}
+
+
+/// If debugging is enabled in the VM, installs a logger that sends messages to the FVM log syscall.
+/// Messages are prefixed with "[LEVEL] ".
+/// If debugging is not enabled, no logger will be installed which means that log!() and
+/// similar calls will be dropped without either formatting args or making a syscall.
+/// Note that, when debugging, the log syscalls will charge gas that wouldn't be charged
+/// when debugging is not enabled.
+///
+/// Note: this is similar to fvm::debug::init_logging() from the FVM SDK, but
+/// that doesn't work (at FVM SDK v2.2).
+fn init_logging() {
+    struct Logger;
+
+    impl log::Log for Logger {
+        fn enabled(&self, _: &log::Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &log::Record) {
+            // Note the log system won't automatically call enabled() before this,
+            // so it's canonical to check it here.
+            // But logging must have been enabled at initialisation time in order for
+            // the logger to be installed.
+            // There's currently no use for dynamically disabling logging, so just skip checking.
+            let msg = format!("[{}] {}", record.level(), record.args());
+            fvm::debug::log(msg);
+        }
+
+        fn flush(&self) {}
     }
 }
 

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -34,7 +34,9 @@ use fvm_ipld_encoding::ipld_block::IpldBlock;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
-pub trait Runtime<BS: Blockstore>: Primitives {
+pub trait Runtime: Primitives {
+    type Blockstore: Blockstore;
+
     /// The network protocol version number at the current epoch.
     fn network_version(&self) -> NetworkVersion;
 
@@ -66,7 +68,7 @@ pub trait Runtime<BS: Blockstore>: Primitives {
     fn resolve_address(&self, address: &Address) -> Option<Address>;
 
     /// Look up the code ID at an actor address.
-    fn get_actor_code_cid(&self, addr: &Address) -> Option<Cid>;
+    fn get_actor_code_cid(&self, id: &ActorID) -> Option<Cid>;
 
     /// Initializes the state object.
     /// This is only valid when the state has not yet been initialized.
@@ -89,7 +91,7 @@ pub trait Runtime<BS: Blockstore>: Primitives {
         F: FnOnce(&mut T, &mut Self) -> Result<RT, ActorError>;
 
     /// Returns reference to blockstore
-    fn store(&self) -> &BS;
+    fn store(&self) -> &Self::Blockstore;
 
     /// Sends a message to another actor, returning the exit code and return value envelope.
     /// If the invoked method does not return successfully, its state changes

--- a/runtime/src/runtime/mod.rs
+++ b/runtime/src/runtime/mod.rs
@@ -3,7 +3,6 @@
 
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::consensus::ConsensusFault;

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -265,8 +265,7 @@ pub fn expect_abort_contains_message<T: fmt::Debug>(
     res: Result<T, ActorError>,
 ) {
     let err = res.expect_err(&format!(
-        "expected abort with exit code {}, but call succeeded",
-        expect_exit_code
+        "expected abort with exit code {expect_exit_code}, but call succeeded"
     ));
     assert_eq!(
         err.exit_code(),
@@ -279,9 +278,7 @@ pub fn expect_abort_contains_message<T: fmt::Debug>(
     let err_msg = err.msg();
     assert!(
         err.msg().contains(expect_msg),
-        "expected err message '{}' to contain '{}'",
-        err_msg,
-        expect_msg,
+        "expected err message '{err_msg}' to contain '{expect_msg}'",
     );
 }
 
@@ -599,8 +596,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
             .unwrap();
         assert_eq!(
             &types, &expected_caller_type,
-            "unexpected validate caller code {:?}, expected {:?}",
-            types, expected_caller_type,
+            "unexpected validate caller code {types:?}, expected {expected_caller_type:?}"
         );
 
         for expected in &types {
@@ -728,11 +724,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
 
         assert!(
             !self.expectations.borrow_mut().expect_sends.is_empty(),
-            "unexpected message to: {:?} method: {:?}, value: {:?}, params: {:?}",
-            to,
-            method,
-            value,
-            params
+            "unexpected message to: {to:?} method: {method:?}, value: {value:?}, params: {params:?}"
         );
 
         let expected_msg = self
@@ -803,7 +795,7 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         }
         let exp_act = self.expectations.borrow_mut().expect_delete_actor.take();
         if exp_act.is_none() {
-            panic!("unexpected call to delete actor: {}", addr);
+            panic!("unexpected call to delete actor: {addr}");
         }
         if exp_act.as_ref().unwrap() != addr {
             panic!(
@@ -837,14 +829,12 @@ impl<BS: Blockstore> Runtime for MockRuntime<BS> {
         let mut exs = self.expectations.borrow_mut();
         assert!(
             !exs.expect_gas_charge.is_empty(),
-            "unexpected gas charge {:?}",
-            value
+            "unexpected gas charge {value:?}"
         );
         let expected = exs.expect_gas_charge.pop_front().unwrap();
         assert_eq!(
             expected, value,
-            "expected gas charge {:?}, actual {:?}",
-            expected, value
+            "expected gas charge {expected:?}, actual {value:?}"
         );
     }
 

--- a/runtime/src/util/cbor.rs
+++ b/runtime/src/util/cbor.rs
@@ -9,8 +9,7 @@ pub fn serialize_vec<T>(value: &T, desc: &str) -> Result<Vec<u8>, ActorError>
 where
     T: ser::Serialize + ?Sized,
 {
-    to_vec(value)
-        .map_err(|e| ActorError::serialization(format!("failed to serialize {}: {}", desc, e)))
+    to_vec(value).map_err(|e| ActorError::serialization(format!("failed to serialize {desc}: {e}")))
 }
 
 /// Serializes a structure as CBOR bytes, returning a serialization error on failure.
@@ -26,7 +25,7 @@ where
 /// `desc` is a noun phrase for the object being deserialized, included in any error message.
 pub fn deserialize<O: de::DeserializeOwned>(v: &RawBytes, desc: &str) -> Result<O, ActorError> {
     v.deserialize()
-        .map_err(|e| ActorError::serialization(format!("failed to deserialize {}: {}", desc, e)))
+        .map_err(|e| ActorError::serialization(format!("failed to deserialize {desc}: {e}")))
 }
 
 /// Deserialises CBOR-encoded bytes as a method parameters object.


### PR DESCRIPTION
This PR:
- Propagates many of the upgrades from `filecoin-project/builtin-actors/runtime`
- It bumps many dependencies.
- It implements a new actor dispatcher.
- It introduces `FRC42` method name dispatcher to example actor.
- It significantly simplifies method invocation and the `Runtime` generics.

This version of package includes breaking changes that need to be propagated to IPC actors. __Do not merge this PR until we have propagated the changes to the actors.__