### PR TITLE
add ethereum address to fvm-utils

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,3 +20,5 @@ integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
+hex = "0.4.3"
+uint = { version = "0.9.3", default-features = false }

--- a/primitives/src/ethaddr.rs
+++ b/primitives/src/ethaddr.rs
@@ -1,0 +1,207 @@
+use std::str::FromStr;
+
+use crate::uints::U256;
+use fil_actors_runtime::EAM_ACTOR_ID;
+use fvm_ipld_encoding::{serde, strict_bytes};
+use fvm_shared::address::Address;
+use fvm_shared::ActorID;
+
+/// A Filecoin address as represented in the FEVM runtime (also called EVM-form).
+#[derive(serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Copy)]
+pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
+
+/// Converts a U256 to an EthAddress by taking the lower 20 bytes.
+///
+/// Per the EVM spec, this simply discards the high bytes.
+impl From<U256> for EthAddress {
+    fn from(v: U256) -> Self {
+        let mut bytes = [0u8; 32];
+        v.to_big_endian(&mut bytes);
+        Self(bytes[12..].try_into().unwrap())
+    }
+}
+
+impl std::fmt::Debug for EthAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+impl FromStr for EthAddress {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Check if it has the 0x prefix
+        if s.len() > 2 && &s[..2] == "0x" {
+            return Self::from_str(&s[2..]);
+        }
+
+        let bytes = hex::decode(s)?;
+        if bytes.len() != 20 {
+            return Err(hex::FromHexError::InvalidStringLength);
+        }
+        let mut addr = [0u8; 20];
+        addr.copy_from_slice(&bytes);
+        Ok(Self(addr))
+    }
+}
+
+impl From<EthAddress> for Address {
+    fn from(addr: EthAddress) -> Self {
+        From::from(&addr)
+    }
+}
+
+impl From<&EthAddress> for Address {
+    fn from(addr: &EthAddress) -> Self {
+        if let Some(id) = addr.as_id() {
+            Address::new_id(id)
+        } else {
+            Address::new_delegated(EAM_ACTOR_ID, addr.as_ref()).unwrap()
+        }
+    }
+}
+
+impl EthAddress {
+    /// Returns a "null" address.
+    pub const fn null() -> Self {
+        Self([0u8; 20])
+    }
+
+    /// Returns an EVM-form ID address from actor ID.
+    pub fn from_id(id: u64) -> EthAddress {
+        let mut bytes = [0u8; 20];
+        bytes[0] = 0xff;
+        bytes[12..].copy_from_slice(&id.to_be_bytes());
+        EthAddress(bytes)
+    }
+
+    /// Interpret the EVM word as an ID address in EVM-form, and return a Filecoin ID address if
+    /// that's the case.
+    ///
+    /// An ID address starts with 0xff (msb), and contains the u64 in the last 8 bytes.
+    /// We assert that everything in between are 0x00, otherwise we've gotten an illegal address.
+    ///
+    /// 0    1-11       12
+    /// 0xff \[0x00...] [id address...]
+    pub fn as_id(&self) -> Option<ActorID> {
+        if !self.is_id() {
+            return None;
+        }
+        Some(u64::from_be_bytes(self.0[12..].try_into().unwrap()))
+    }
+
+    /// Returns this Address as an EVM word.
+    #[inline]
+    pub fn as_evm_word(&self) -> U256 {
+        U256::from_big_endian(&self.0)
+    }
+
+    /// Returns true if this is the null/zero EthAddress.
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.0 == [0; 20]
+    }
+
+    /// Returns true if the EthAddress refers to an address in the precompile range.
+    /// [reference](https://github.com/filecoin-project/ref-fvm/issues/1164#issuecomment-1371304676)
+    #[inline]
+    pub fn is_precompile(&self) -> bool {
+        // Exact index is not checked since it is unknown to the EAM what precompiles exist in the EVM actor.
+        // 0 indexes of both ranges are not assignable as well but are _not_ precompile address.
+        let [prefix, middle @ .., _index] = self.0;
+        (prefix == 0xfe || prefix == 0x00) && middle == [0u8; 18]
+    }
+
+    /// Returns true if the EthAddress is an actor ID embedded in an eth address.
+    #[inline]
+    pub fn is_id(&self) -> bool {
+        self.0[0] == 0xff && self.0[1..12].iter().all(|&i| i == 0)
+    }
+}
+
+impl AsRef<[u8]> for EthAddress {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::EthAddress;
+    use crate::uints::U256;
+
+    // padding (12 bytes)
+    const TYPE_PADDING: &[u8] = &[0; 12];
+    // ID address marker (1 byte)
+    const ID_ADDRESS_MARKER: &[u8] = &[0xff];
+    // ID address marker (1 byte)
+    const GOOD_ADDRESS_PADDING: &[u8] = &[
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]; // padding for inner u64 (11 bytes)
+
+    #[test]
+    fn ethaddr_from_str() {
+        EthAddress::from_str("0x6BE1Ccf648c74800380d0520D797a170c808b624").unwrap();
+    }
+
+    macro_rules! id_address_test {
+        ($($name:ident: $input:expr => $expectation:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let evm_bytes = $input.concat();
+                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                assert_eq!(
+                    evm_addr.as_id(),
+                    $expectation
+                );
+
+                // test inverse conversion, if a valid ID address was supplied
+                if let Some(fil_id) = $expectation {
+                    assert_eq!(EthAddress::from_id(fil_id), evm_addr);
+                }
+            }
+        )*
+        };
+    }
+
+    id_address_test! {
+        good_address_1: [
+            TYPE_PADDING,
+            ID_ADDRESS_MARKER,
+            GOOD_ADDRESS_PADDING,
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => Some(1),
+
+        good_address_2: [
+            TYPE_PADDING,
+            ID_ADDRESS_MARKER,
+            GOOD_ADDRESS_PADDING,
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => Some(u16::MAX as u64),
+
+        bad_marker: [
+            TYPE_PADDING,
+            &[0xfa],
+            GOOD_ADDRESS_PADDING,
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => None,
+
+        bad_padding: [
+            TYPE_PADDING,
+            ID_ADDRESS_MARKER,
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01], // bad padding
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => None,
+
+        bad_marker_and_padding: [
+            TYPE_PADDING,
+            &[0xfa],
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01], // bad padding
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => None,
+    }
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,11 +3,14 @@ use std::{fmt::Display, marker::PhantomData};
 use cid::{multihash::Code, Cid};
 
 mod amt;
+mod ethaddr;
 mod hamt;
 mod link;
 mod taddress;
+mod uints;
 
 pub use amt::TAmt;
+pub use ethaddr::*;
 pub use hamt::THamt;
 pub use link::TLink;
 pub use taddress::*;

--- a/primitives/src/uints.rs
+++ b/primitives/src/uints.rs
@@ -1,0 +1,340 @@
+// to silence construct_uint! clippy warnings
+// see https://github.com/paritytech/parity-common/issues/660
+#![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern)]
+
+#[doc(inline)]
+pub use uint::byteorder;
+
+use serde::{Deserialize, Serialize};
+//use substrate_bn::arith;
+
+use {
+    fvm_shared::bigint::BigInt, fvm_shared::econ::TokenAmount, std::cmp::Ordering, std::fmt,
+    uint::construct_uint,
+};
+
+construct_uint! { pub struct U256(4); } // ethereum word size
+construct_uint! { pub struct U512(8); } // used for addmod and mulmod opcodes
+
+// Convenience method for comparing against a small value.
+impl PartialOrd<u64> for U256 {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        if self.0[3] > 0 || self.0[2] > 0 || self.0[1] > 0 {
+            Some(Ordering::Greater)
+        } else {
+            self.0[0].partial_cmp(other)
+        }
+    }
+}
+
+impl PartialEq<u64> for U256 {
+    fn eq(&self, other: &u64) -> bool {
+        self.0[0] == *other && self.0[1] == 0 && self.0[2] == 0 && self.0[3] == 0
+    }
+}
+
+impl U256 {
+    pub const BITS: u32 = 256;
+    pub const ZERO: Self = U256::from_u64(0);
+    pub const ONE: Self = U256::from_u64(1);
+    pub const I128_MIN: Self = U256([0, 0, 0, i64::MIN as u64]);
+
+    #[inline(always)]
+    pub const fn from_u128_words(high: u128, low: u128) -> U256 {
+        U256([
+            low as u64,
+            (low >> u64::BITS) as u64,
+            high as u64,
+            (high >> u64::BITS) as u64,
+        ])
+    }
+
+    #[inline(always)]
+    pub const fn from_u64(value: u64) -> U256 {
+        U256([value, 0, 0, 0])
+    }
+
+    #[inline(always)]
+    pub const fn i256_is_negative(&self) -> bool {
+        (self.0[3] as i64) < 0
+    }
+
+    /// turns a i256 value to negative
+    #[inline(always)]
+    pub fn i256_neg(&self) -> U256 {
+        if self.is_zero() {
+            U256::ZERO
+        } else {
+            !*self + U256::ONE
+        }
+    }
+
+    #[inline(always)]
+    pub fn i256_cmp(&self, other: &U256) -> Ordering {
+        // true > false:
+        // - true < positive:
+        match other.i256_is_negative().cmp(&self.i256_is_negative()) {
+            Ordering::Equal => self.cmp(other),
+            sign_cmp => sign_cmp,
+        }
+    }
+
+    #[inline]
+    pub fn i256_div(&self, other: &U256) -> U256 {
+        if self.is_zero() || other.is_zero() {
+            // EVM defines X/0 to be 0.
+            return U256::ZERO;
+        }
+
+        let mut first = *self;
+        let mut second = *other;
+
+        // Record and strip the signs. We add them back at the end.
+        let first_neg = first.i256_is_negative();
+        let second_neg = second.i256_is_negative();
+
+        if first_neg {
+            first = first.i256_neg()
+        }
+
+        if second_neg {
+            second = second.i256_neg()
+        }
+
+        let d = first / second;
+
+        // Flip the sign back if necessary.
+        if d.is_zero() || first_neg == second_neg {
+            d
+        } else {
+            d.i256_neg()
+        }
+    }
+
+    #[inline]
+    pub fn i256_mod(&self, other: &U256) -> U256 {
+        if self.is_zero() || other.is_zero() {
+            // X % 0  or 0 % X is always 0.
+            return U256::ZERO;
+        }
+
+        let mut first = *self;
+        let mut second = *other;
+
+        // Record and strip the sign.
+        let negative = first.i256_is_negative();
+        if negative {
+            first = first.i256_neg();
+        }
+
+        if second.i256_is_negative() {
+            second = second.i256_neg()
+        }
+
+        let r = first % second;
+
+        // Restore the sign.
+        if negative && !r.is_zero() {
+            r.i256_neg()
+        } else {
+            r
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut buf = [0u8; 32];
+        self.to_big_endian(&mut buf);
+        buf
+    }
+
+    /// Returns the low 64 bits, saturating the value to u64 max if it is larger
+    pub fn to_u64_saturating(&self) -> u64 {
+        if self.bits() > 64 {
+            u64::MAX
+        } else {
+            self.0[0]
+        }
+    }
+}
+
+impl U512 {
+    pub fn low_u256(&self) -> U256 {
+        let [a, b, c, d, ..] = self.0;
+        U256([a, b, c, d])
+    }
+}
+
+impl From<&TokenAmount> for U256 {
+    fn from(amount: &TokenAmount) -> U256 {
+        let (_, bytes) = amount.atto().to_bytes_be();
+        U256::from(bytes.as_slice())
+    }
+}
+
+impl From<U256> for U512 {
+    fn from(v: U256) -> Self {
+        let [a, b, c, d] = v.0;
+        U512([a, b, c, d, 0, 0, 0, 0])
+    }
+}
+
+impl From<&U256> for TokenAmount {
+    fn from(ui: &U256) -> TokenAmount {
+        let mut bits = [0u8; 32];
+        ui.to_big_endian(&mut bits);
+        TokenAmount::from_atto(BigInt::from_bytes_be(fvm_shared::bigint::Sign::Plus, &bits))
+    }
+}
+
+impl Serialize for U256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut bytes = [0u8; 32];
+        self.to_big_endian(&mut bytes);
+        serializer.serialize_bytes(zeroless_view(&bytes))
+    }
+}
+
+impl<'de> Deserialize<'de> for U256 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = U256;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "at most 32 bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v.len() > 32 {
+                    return Err(serde::de::Error::invalid_length(v.len(), &self));
+                }
+                Ok(U256::from_big_endian(v))
+            }
+        }
+        deserializer.deserialize_bytes(Visitor)
+    }
+}
+
+fn zeroless_view(v: &impl AsRef<[u8]>) -> &[u8] {
+    let v = v.as_ref();
+    &v[v.iter().take_while(|&&b| b == 0).count()..]
+}
+
+#[cfg(test)]
+mod tests {
+    use fvm_ipld_encoding::{BytesDe, BytesSer, RawBytes};
+
+    use {super::*, core::num::Wrapping};
+
+    #[test]
+    fn div_i256() {
+        assert_eq!(Wrapping(i8::MIN) / Wrapping(-1), Wrapping(i8::MIN));
+        assert_eq!(i8::MAX / -1, -i8::MAX);
+
+        let zero = U256::ZERO;
+        let one = U256::ONE;
+        let one_hundred = U256::from(100);
+        let fifty = U256::from(50);
+        let two = U256::from(2);
+        let neg_one_hundred = U256::from(100);
+        let minus_one = U256::from(1);
+        let max_value = U256::from(2).pow(255.into()) - 1;
+        let neg_max_value = U256::from(2).pow(255.into()) - 1;
+
+        assert_eq!(U256::I128_MIN.i256_div(&minus_one), U256::I128_MIN);
+        assert_eq!(U256::I128_MIN.i256_div(&one), U256::I128_MIN);
+        assert_eq!(
+            U256::I128_MIN.i256_div(&two),
+            U256([0, 0, 0, i64::MIN as u64 + (i64::MIN as u64 >> 1)])
+        );
+        assert_eq!(one.i256_div(&U256::I128_MIN), zero);
+        assert_eq!(max_value.i256_div(&one), max_value);
+        assert_eq!(max_value.i256_div(&minus_one), neg_max_value);
+        assert_eq!(one_hundred.i256_div(&minus_one), neg_one_hundred);
+        assert_eq!(one_hundred.i256_div(&two), fifty);
+
+        assert_eq!(zero.i256_div(&zero), zero);
+        assert_eq!(one.i256_div(&zero), zero);
+        assert_eq!(zero.i256_div(&one), zero);
+    }
+
+    #[test]
+    fn mod_i256() {
+        let zero = U256::ZERO;
+        let one = U256::ONE;
+        let one_hundred = U256::from(100);
+        let two = U256::from(2);
+        let three = U256::from(3);
+
+        let neg_one_hundred = U256::from(100).i256_neg();
+        let minus_one = U256::from(1).i256_neg();
+        let neg_three = U256::from(3).i256_neg();
+        let max_value = U256::from(2).pow(255.into()) - 1;
+
+        // zero
+        assert_eq!(minus_one.i256_mod(&U256::ZERO), U256::ZERO);
+        assert_eq!(max_value.i256_mod(&U256::ZERO), U256::ZERO);
+        assert_eq!(U256::ZERO.i256_mod(&U256::ZERO), U256::ZERO);
+
+        assert_eq!(minus_one.i256_mod(&two), minus_one);
+        assert_eq!(U256::I128_MIN.i256_mod(&one), 0);
+        assert_eq!(one.i256_mod(&U256::I128_MIN), one);
+        assert_eq!(one.i256_mod(&U256::from(i128::MAX)), one);
+
+        assert_eq!(max_value.i256_mod(&minus_one), zero);
+        assert_eq!(neg_one_hundred.i256_mod(&minus_one), zero);
+        assert_eq!(one_hundred.i256_mod(&two), zero);
+        assert_eq!(one_hundred.i256_mod(&neg_three), one);
+
+        assert_eq!(neg_one_hundred.i256_mod(&three), minus_one);
+
+        let a = U256::from(95).i256_neg();
+        let b = U256::from(256);
+        assert_eq!(a % b, U256::from(161))
+    }
+
+    #[test]
+    fn negative_i256() {
+        assert_eq!(U256::ZERO.i256_neg(), U256::ZERO);
+
+        let one = U256::ONE.i256_neg();
+        assert!(one.i256_is_negative());
+
+        let neg_one = U256::from(&[0xff; 32]);
+        let pos_one = neg_one.i256_neg();
+        assert_eq!(pos_one, U256::ONE);
+    }
+
+    #[test]
+    fn u256_serde() {
+        let encoded = RawBytes::serialize(U256::from(0x4d2)).unwrap();
+        let BytesDe(bytes) = encoded.deserialize().unwrap();
+        assert_eq!(bytes, &[0x04, 0xd2]);
+        let decoded: U256 = encoded.deserialize().unwrap();
+        assert_eq!(decoded, 0x4d2);
+    }
+
+    #[test]
+    fn u256_empty() {
+        let encoded = RawBytes::serialize(U256::from(0)).unwrap();
+        let BytesDe(bytes) = encoded.deserialize().unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn u256_overflow() {
+        let encoded = RawBytes::serialize(BytesSer(&[1; 33])).unwrap();
+        encoded
+            .deserialize::<U256>()
+            .expect_err("should have failed to decode an over-large u256");
+    }
+}

--- a/primitives/src/uints.rs
+++ b/primitives/src/uints.rs
@@ -141,14 +141,14 @@ impl U256 {
         }
     }
 
-    pub fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(self) -> [u8; 32] {
         let mut buf = [0u8; 32];
         self.to_big_endian(&mut buf);
         buf
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
-    pub fn to_u64_saturating(&self) -> u64 {
+    pub fn to_u64_saturating(self) -> u64 {
         if self.bits() > 64 {
             u64::MAX
         } else {

--- a/runtime/src/builtin/singletons.rs
+++ b/runtime/src/builtin/singletons.rs
@@ -25,6 +25,7 @@ define_singletons! {
     STORAGE_MARKET_ACTOR = 5,
     VERIFIED_REGISTRY_ACTOR = 6,
     DATACAP_TOKEN_ACTOR = 7,
+    EAM_ACTOR = 10,
     BURNT_FUNDS_ACTOR = 99,
 }
 


### PR DESCRIPTION
This PR implements a representation of Ethereum addresses into our `fvm_utils` primitives.
